### PR TITLE
Force mmseqs2 database types, so nucl seq are not mistaken as proteins, disable peptide e-value

### DIFF
--- a/scripts/cluster_pdb_mmcifs.py
+++ b/scripts/cluster_pdb_mmcifs.py
@@ -758,6 +758,8 @@ if __name__ == "__main__":
             coverage=0.8,
             coverage_mode=0,
             extra_parameters={
+                # force protein mode
+                "--dbtype": 1,
                 # cluster reassign improves clusters by reassigning sequences to the best cluster
                 # and fixes transitivity issues of the cascade clustering
                 "--cluster-reassign": 1,
@@ -777,6 +779,8 @@ if __name__ == "__main__":
             coverage=0.8,
             coverage_mode=0,
             extra_parameters={
+                # force nucleotide mode
+                "--dbtype": 2,
                 # 7 or 8 should work best, something to test
                 "-k": 8,
                 # there is currently an issue in mmseqs2 with nucleotide search and spaced k-mers
@@ -800,8 +804,9 @@ if __name__ == "__main__":
             coverage_mode=0,
             # some of these parameters are from the spacepharer optimized parameters
             # these were for short CRISPR spacer recognition, so they should work well for arbitrary peptides
-            # this is a adhoc solution, with some recent new introduction like the ungapped prefilter
             extra_parameters={
+                # force protein mode
+                "--dbtype": 1,
                 # spacepharer optimized parameters
                 "--gap-open": 16,
                 "--gap-extend": 2,
@@ -817,8 +822,9 @@ if __name__ == "__main__":
                 "--comp-bias-corr": 0,
                 # let more things through the prefilter
                 "--min-ungapped-score": 5,
-                # Try disabling completely with "inf"?
-                "-e": 1,
+                # Let's disable e-values as these are too short for reliable homology anyway
+                # The most we can do is to collapse nearly identical peptides
+                "-e": "inf",
                 # see above
                 "--cluster-reassign": 1,
             },


### PR DESCRIPTION
## What does this PR do?

<!--
Please include a summary of the change and which issue is fixed.
Please also include relevant motivation and context.
List any dependencies that are required for this change.
List all the breaking changes introduced by this pull request.
-->

Fixes #\<issue_number>

## Before submitting

- [ ] Did you make sure **title is self-explanatory** and **the description concisely explains the PR**?
- [ ] Did you make sure your **PR does only one thing**, instead of bundling different changes together?
- [ ] Did you list all the **breaking changes** introduced by this pull request?
- [ ] Did you **test your PR locally** with `pytest` command?
- [ ] Did you **run pre-commit hooks** with `pre-commit run -a` command?

## Did you have fun?

Make sure you had fun coding 🙃
